### PR TITLE
Fix null min_age_in_months filter

### DIFF
--- a/pages/2_Adult_Clinical_Trials.py
+++ b/pages/2_Adult_Clinical_Trials.py
@@ -107,8 +107,9 @@ def fetch_adult_trials_in_canada(engine):
         df['min_age_in_months'] = df['minimum_age'].apply(parse_age_to_months)
         df['max_age_in_months'] = df['maximum_age'].apply(parse_age_to_months)
 
-        # Filter out any studies that are seniors-only
-        adult_df = df[(df['min_age_in_months'] <= 780)].copy()
+        # Filter out any studies that are have a min age of 65 years or where
+        # min age is undefined
+        adult_df = df[(df['min_age_in_months'].isna()) | (df['min_age_in_months'] <= 780)].copy()
         
         # Add some useful columns for analysis
         if not adult_df.empty and 'start_date' in adult_df.columns:


### PR DESCRIPTION
This change ensures that trials with null min_age_in_months are retained instead of being excluded.